### PR TITLE
Feat/rabbit mq

### DIFF
--- a/auth-service/package.json
+++ b/auth-service/package.json
@@ -14,6 +14,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "amqplib": "^0.10.3",
     "bcrypt": "^5.1.1",
     "cors": "^2.8.5",
     "dotenv": "^16.4.4",
@@ -27,6 +28,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@types/amqplib": "^0.10.5",
     "@types/bcrypt": "^5.0.2",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",

--- a/auth-service/src/index.ts
+++ b/auth-service/src/index.ts
@@ -5,10 +5,17 @@ import { AuthDataSource } from "./db/datasource";
 import AuthRouter from "./routes/auth.routes";
 import AppError from "./utils/AppError";
 import morgan from "morgan";
+import { connectToRabbit } from "./mq";
 dotenv.config();
 
 export default async function initializeApp() {
   await AuthDataSource.initialize();
+
+  const mqService = await connectToRabbit();
+  if (!mqService) {
+    throw new Error("Failed to connect to RabbitMQ");
+  }
+
   const app = express();
 
   app.use(express.json());

--- a/auth-service/src/index.ts
+++ b/auth-service/src/index.ts
@@ -5,13 +5,15 @@ import { AuthDataSource } from "./db/datasource";
 import AuthRouter from "./routes/auth.routes";
 import AppError from "./utils/AppError";
 import morgan from "morgan";
-import { connectToRabbit } from "./mq";
+import { MQService, connectToRabbit } from "./mq";
 dotenv.config();
+
+export let mqService: MQService | undefined;
 
 export default async function initializeApp() {
   await AuthDataSource.initialize();
 
-  const mqService = await connectToRabbit();
+  mqService = await connectToRabbit();
   if (!mqService) {
     throw new Error("Failed to connect to RabbitMQ");
   }

--- a/auth-service/src/mq/index.ts
+++ b/auth-service/src/mq/index.ts
@@ -30,7 +30,9 @@ export async function connectToRabbit() {
   try {
     const connection = await amqp.connect(constants.RABBITMQ_URL);
     const channel = await connection.createChannel();
-    return new MQService(connection, channel);
+    const mqService = new MQService(connection, channel);
+    mqService.initializeExchanges(["user_created"]);
+    return mqService;
   } catch (e) {
     console.error(e);
   }

--- a/auth-service/src/mq/index.ts
+++ b/auth-service/src/mq/index.ts
@@ -1,7 +1,7 @@
 import amqp from "amqplib";
 import constants from "../utils/constants";
 
-class MQService {
+export class MQService {
   private connection: amqp.Connection;
   private channel: amqp.Channel;
 

--- a/auth-service/src/mq/index.ts
+++ b/auth-service/src/mq/index.ts
@@ -1,0 +1,37 @@
+import amqp from "amqplib";
+import constants from "../utils/constants";
+
+class MQService {
+  private connection: amqp.Connection;
+  private channel: amqp.Channel;
+
+  constructor(connection: amqp.Connection, channel: amqp.Channel) {
+    this.connection = connection;
+    this.channel = channel;
+  }
+
+  async initializeExchanges(exchangeList: string[]) {
+    for (const ex of exchangeList) {
+      await this.channel.assertExchange(ex, "fanout", { durable: false });
+    }
+  }
+
+  async sendMessage(message: string, exchange: string) {
+    await this.channel.publish(exchange, "", Buffer.from(message));
+  }
+
+  async shutDown() {
+    await this.channel.close();
+    await this.connection.close();
+  }
+}
+
+export async function connectToRabbit() {
+  try {
+    const connection = await amqp.connect(constants.RABBITMQ_URL);
+    const channel = await connection.createChannel();
+    return new MQService(connection, channel);
+  } catch (e) {
+    console.error(e);
+  }
+}

--- a/auth-service/src/service/authUser.service.ts
+++ b/auth-service/src/service/authUser.service.ts
@@ -6,6 +6,7 @@ import validator from "validator";
 import bcrypt from "bcrypt";
 import { randomUUID } from "crypto";
 import AppError from "../utils/AppError";
+import { mqService } from "..";
 
 dotenv.config();
 
@@ -56,6 +57,12 @@ async function signup(
   });
 
   const savedUser = await repository.save(user);
+
+  mqService?.sendMessage(
+    JSON.stringify({ email: savedUser.email, id: savedUser.id }),
+    "user_created",
+  );
+
   return {
     user: savedUser,
     accessToken: createJWTToken(user.id),

--- a/auth-service/src/utils/constants.ts
+++ b/auth-service/src/utils/constants.ts
@@ -1,4 +1,4 @@
-const RABBITMQ_URL = process.env.RABBITMQ_URL || "ampq://localhost:5672";
+const RABBITMQ_URL = process.env.RABBITMQ_URL || "amqp://localhost:5672";
 
 const constants = {
   RABBITMQ_URL,

--- a/auth-service/yarn.lock
+++ b/auth-service/yarn.lock
@@ -2,6 +2,15 @@
 # yarn lockfile v1
 
 
+"@acuminous/bitsyntax@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@acuminous/bitsyntax/-/bitsyntax-0.1.2.tgz#e0b31b9ee7ad1e4dd840c34864327c33d9f1f653"
+  integrity sha512-29lUK80d1muEQqiUsSo+3A0yP6CdspgC95EnKBMi22Xlwt79i/En4Vr67+cXhU+cZjbti3TgGGC5wy1stIywVQ==
+  dependencies:
+    buffer-more-ints "~1.0.0"
+    debug "^4.3.4"
+    safe-buffer "~5.1.2"
+
 "@ampproject/remapping@^2.2.0":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.1.tgz#99e8e11851128b8702cd57c33684f1d0f260b630"
@@ -593,6 +602,13 @@
   resolved "https://registry.yarnpkg.com/@sqltools/formatter/-/formatter-1.2.5.tgz#3abc203c79b8c3e90fd6c156a0c62d5403520e12"
   integrity sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==
 
+"@types/amqplib@^0.10.5":
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/@types/amqplib/-/amqplib-0.10.5.tgz#fd883eddfbd669702a727fa10007b27c4c1e6ec7"
+  integrity sha512-/cSykxROY7BWwDoi4Y4/jLAuZTshZxd8Ey1QYa/VaXriMotBDoou7V/twJiOSHzU6t1Kp1AHAUXGCgqq+6DNeg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/babel__core@^7.1.14":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
@@ -820,6 +836,16 @@ agent-base@6:
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
     debug "4"
+
+amqplib@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/amqplib/-/amqplib-0.10.3.tgz#e186a2f74521eb55ec54db6d25ae82c29c1f911a"
+  integrity sha512-UHmuSa7n8vVW/a5HGh2nFPqAEr8+cD4dEZ6u9GjP91nHfr1a54RyAKyra7Sb5NH7NBKOUlyQSMXIp0qAixKexw==
+  dependencies:
+    "@acuminous/bitsyntax" "^0.1.2"
+    buffer-more-ints "~1.0.0"
+    readable-stream "1.x >=1.1.9"
+    url-parse "~1.5.10"
 
 ansi-escapes@^4.2.1:
   version "4.3.2"
@@ -1069,6 +1095,11 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
+buffer-more-ints@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz#ef4f8e2dddbad429ed3828a9c55d44f05c611422"
+  integrity sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==
+
 buffer-writer@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/buffer-writer/-/buffer-writer-2.0.0.tgz#ce7eb81a38f7829db09c873f2fbb792c0c98ec04"
@@ -1275,6 +1306,11 @@ cookie@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+
+core-util-is@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
+  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
 cors@^2.8.5:
   version "2.8.5"
@@ -1822,7 +1858,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -1882,6 +1918,11 @@ is-stream@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -2977,6 +3018,11 @@ qs@6.11.0:
   dependencies:
     side-channel "^1.0.4"
 
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
+
 range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
@@ -2996,6 +3042,16 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+"readable-stream@1.x >=1.1.9":
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
+  integrity sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
 
 readable-stream@^3.6.0:
   version "3.6.2"
@@ -3022,6 +3078,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"
@@ -3056,7 +3117,7 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-safe-buffer@5.1.2:
+safe-buffer@5.1.2, safe-buffer@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -3258,6 +3319,11 @@ string_decoder@^1.1.1:
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
+
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
@@ -3468,6 +3534,14 @@ update-browserslist-db@^1.0.13:
   dependencies:
     escalade "^3.1.1"
     picocolors "^1.0.0"
+
+url-parse@~1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 util-deprecate@^1.0.1:
   version "1.0.2"

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@typegoose/typegoose": "^11.4.1",
         "@types/morgan": "^1.9.9",
+        "amqplib": "^0.10.3",
         "bcrypt": "^5.1.1",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
@@ -24,6 +25,7 @@
         "validator": "^13.11.0"
       },
       "devDependencies": {
+        "@types/amqplib": "^0.10.5",
         "@types/bcrypt": "^5.0.0",
         "@types/cors": "^2.8.13",
         "@types/express": "^4.17.17",
@@ -40,6 +42,45 @@
         "node": "19.x",
         "npm": "9.x"
       }
+    },
+    "node_modules/@acuminous/bitsyntax": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@acuminous/bitsyntax/-/bitsyntax-0.1.2.tgz",
+      "integrity": "sha512-29lUK80d1muEQqiUsSo+3A0yP6CdspgC95EnKBMi22Xlwt79i/En4Vr67+cXhU+cZjbti3TgGGC5wy1stIywVQ==",
+      "dependencies": {
+        "buffer-more-ints": "~1.0.0",
+        "debug": "^4.3.4",
+        "safe-buffer": "~5.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/@acuminous/bitsyntax/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@acuminous/bitsyntax/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/@acuminous/bitsyntax/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
@@ -1987,6 +2028,15 @@
         "mongoose": "~7.5.0"
       }
     },
+    "node_modules/@types/amqplib": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.10.5.tgz",
+      "integrity": "sha512-/cSykxROY7BWwDoi4Y4/jLAuZTshZxd8Ey1QYa/VaXriMotBDoou7V/twJiOSHzU6t1Kp1AHAUXGCgqq+6DNeg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2350,6 +2400,36 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/amqplib": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.3.tgz",
+      "integrity": "sha512-UHmuSa7n8vVW/a5HGh2nFPqAEr8+cD4dEZ6u9GjP91nHfr1a54RyAKyra7Sb5NH7NBKOUlyQSMXIp0qAixKexw==",
+      "dependencies": {
+        "@acuminous/bitsyntax": "^0.1.2",
+        "buffer-more-ints": "~1.0.0",
+        "readable-stream": "1.x >=1.1.9",
+        "url-parse": "~1.5.10"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/amqplib/node_modules/readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/amqplib/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
     },
     "node_modules/ansi-align": {
       "version": "3.0.1",
@@ -2883,6 +2963,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/buffer-more-ints": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
+      "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg=="
     },
     "node_modules/buffer-writer": {
       "version": "2.0.0",
@@ -3449,6 +3534,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -4929,6 +5019,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -8393,6 +8488,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -8618,6 +8718,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -10027,6 +10132,15 @@
       },
       "funding": {
         "url": "https://github.com/yeoman/update-notifier?sponsor=1"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@typegoose/typegoose": "^11.4.1",
     "@types/morgan": "^1.9.9",
+    "amqplib": "^0.10.3",
     "bcrypt": "^5.1.1",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
@@ -35,6 +36,7 @@
     "npm": "9.x"
   },
   "devDependencies": {
+    "@types/amqplib": "^0.10.5",
     "@types/bcrypt": "^5.0.0",
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.17",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -6,10 +6,39 @@ import AppError from "./utils/AppError";
 import { FitlogCoreDataSource } from "./utils/pgres.datasource";
 import RoutineRouter from "./routine/routes/routine.routes";
 import morgan from "morgan";
+import amqp from "amqplib";
+import constants from "./utils/constants";
+import { handleUserCreated } from "./routine/services/routine.service";
 dotenv.config();
 
+export async function connectToMQ() {
+  try {
+    const connection = await amqp.connect(constants.RABBITMQ_URL);
+    const channel = await connection.createChannel();
+    return { connection, channel };
+  } catch (err) {
+    console.error(err);
+  }
+}
 export default async function initializeApp() {
   await FitlogCoreDataSource.initialize();
+  const connectionResult = await connectToMQ();
+  if (connectionResult === undefined) {
+    throw new Error("Failed to connect to RabbitMQ");
+  }
+
+  const { channel } = connectionResult;
+  await channel.assertExchange("user_created", "fanout", { durable: false });
+  const assertQueue = await channel.assertQueue("", { exclusive: true });
+  await channel.bindQueue(assertQueue.queue, "user_created", "");
+
+  channel.consume(assertQueue.queue, async (message) => {
+    if (message === null) {
+      console.log("Null message was received");
+      return;
+    }
+    await handleUserCreated(message);
+  });
   const app = express();
 
   // middleware

--- a/backend/src/mq/EventConsumer.ts
+++ b/backend/src/mq/EventConsumer.ts
@@ -1,0 +1,18 @@
+import { handleUserCreated } from "../routine/services/routine.service";
+
+interface EventConsumer {
+  consume(): Promise<void>;
+}
+
+// serves as list of topics/exchanges that represent one event type
+// MQEventConsumer classes are instantiated based on this list
+export const exchangeList = ["user_created"];
+
+// helper function which returns the event handler based on the exchange
+export function getEventHandlerByExchange(exchange: string) {
+  if (exchange === "user_created") {
+    return handleUserCreated;
+  }
+  throw new Error("Exchange not found");
+}
+export default EventConsumer;

--- a/backend/src/mq/MQEventConsumer.ts
+++ b/backend/src/mq/MQEventConsumer.ts
@@ -1,0 +1,45 @@
+import EventConsumer, { getEventHandlerByExchange } from "./EventConsumer";
+import amqp from "amqplib";
+
+class MQEventConsumer implements EventConsumer {
+  private readonly connection: amqp.Connection;
+  private readonly channel: amqp.Channel;
+  private readonly exchange: string;
+  private readonly eventHandler: (
+    message: amqp.ConsumeMessage,
+  ) => Promise<void>;
+
+  constructor(
+    connection: amqp.Connection,
+    channel: amqp.Channel,
+    exchange: string,
+  ) {
+    this.connection = connection;
+    this.channel = channel;
+    this.exchange = exchange;
+    this.eventHandler = getEventHandlerByExchange(exchange);
+  }
+
+  async consume(): Promise<void> {
+    await this.channel.assertExchange(this.exchange, "fanout", {
+      durable: false,
+    });
+    const assertQueue = await this.channel.assertQueue("", { exclusive: true });
+    await this.channel.bindQueue(assertQueue.queue, this.exchange, "");
+
+    this.channel.consume(assertQueue.queue, (message) => {
+      if (message === null) {
+        console.log(`Null message was received for exchange: ${this.exchange}`);
+        return;
+      }
+      this.eventHandler(message);
+    });
+  }
+
+  async close(): Promise<void> {
+    await this.channel.close();
+    await this.connection.close();
+  }
+}
+
+export default MQEventConsumer;

--- a/backend/src/mq/connect.ts
+++ b/backend/src/mq/connect.ts
@@ -1,0 +1,11 @@
+import amqp from "amqplib";
+import constants from "../utils/constants";
+export async function connectToMQ() {
+  try {
+    const connection = await amqp.connect(constants.RABBITMQ_URL);
+
+    return connection;
+  } catch (err) {
+    console.error(err);
+  }
+}

--- a/backend/src/routine/services/routine.service.ts
+++ b/backend/src/routine/services/routine.service.ts
@@ -2,6 +2,7 @@ import { FitlogCoreDataSource } from "../../utils/pgres.datasource";
 import { Routine } from "../entities/routine.entity";
 import { RoutineUpdateFields } from "../routine.types";
 import AppError from "../../utils/AppError";
+import amqp from "amqplib";
 
 const RoutineRepository = FitlogCoreDataSource.getRepository(Routine);
 
@@ -81,6 +82,10 @@ const _delete = async (routineId: string, userId: string) => {
 
   return RoutineRepository.delete({ id: routineId });
 };
+
+export async function handleUserCreated(message: amqp.ConsumeMessage) {
+  console.log("User created: ", JSON.parse(message.content.toString()));
+}
 
 const RoutineService = {
   post,

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -17,6 +17,7 @@ const nonProd = env === "development" || env === "test";
 const DB_USERNAME = process.env.DB_USERNAME || "postgres";
 const DB_PASSWORD = process.env.DB_PASSWORD || "postgres";
 const DB_PORT = process.env.DB_PORT ? parseInt(process.env.DB_PORT) : 5432;
+const RABBITMQ_URL = process.env.RABBITMQ_URL || "amqp://localhost";
 
 const HTTP = {
   GET: "GET",
@@ -28,6 +29,7 @@ const HTTP = {
 const CORE_SERVICE_URL = process.env.CORE_SERVICE || "http://localhost:8082";
 
 const constants = {
+  RABBITMQ_URL,
   CORE_SERVICE_URL,
   HTTP,
   nonProd,

--- a/compose.yml
+++ b/compose.yml
@@ -45,5 +45,6 @@ services:
     env_file: ./auth-service/.env.compose
     depends_on:
       - db
+      - mq
 volumes:
   pgdata:

--- a/compose.yml
+++ b/compose.yml
@@ -1,4 +1,12 @@
 services:
+  mq:
+    image: rabbitmq:3.13
+    container_name: mq
+    ports:
+      - "5672:5672"
+    volumes:
+      - ~/.docker-conf/rabbitmq/data/:/var/lib/rabbitmq/
+      - ~/.docker-conf/rabbitmq/log/:/var/log/rabbitmq
   db:
     image: postgres:latest
     ports:

--- a/compose.yml
+++ b/compose.yml
@@ -36,6 +36,7 @@ services:
       - ./backend/.env.compose
     depends_on:
       - db
+      - mq
   fitlog_auth_service:
     container_name: fitlog_auth_service
     build:


### PR DESCRIPTION
This PR adds the initial RabbitMQ connection code to two services. The auth service acts as a producer and publishes a message containing the user which was just created after a signup occurs. The core service listens for this exchange type and console logs the parsed user (to be changed soon).

Much of the code is useful boilerplate for connection to RabbitMQ in future services which require the pub sub/fire and forget messaging style.